### PR TITLE
Fixed link to the docs

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -44,7 +44,7 @@ app.controller(
       var previous = null;
 
       var constructDocsURL = function(servicePath) {
-        var currentVersion = 'v201605';
+        var currentVersion = 'v201708';
         return (
             'https://developers.google.com/doubleclick-publishers/' +
             'docs/reference/' + currentVersion + '/' + servicePath);


### PR DESCRIPTION
Fixed link to the docs as the broken link a very annoying when using dfp-playground.appspot.com
The previous one lead to https://developers.google.com/doubleclick-publishers/docs/reference/v201605/...